### PR TITLE
Feature/108 ユーザープロフィール/Firestoreから削除

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,27 +3,15 @@ service cloud.firestore {
   match /databases/{database}/documents {
     match /userProfile/{userId} {
       allow read, write: if true;
-      allow create: if request.auth.uid != null;
-      allow update: if request.auth.uid == resource.data.userId && resource.data.userId == request.resource.userId
-      allow delete: if request.auth.uid == resource.data.userId;
     }
     match /companyProfile/{userId} {
       allow read, write: if true;
-      allow create: if request.auth.uid != null;
-      allow update: if request.auth.uid == resource.data.userId && resource.data.userId == request.resource.userId
-      allow delete: if request.auth.uid == resource.data.userId;
     }
     match /JobPosts/{userId} {
       allow read, write: if true;
-      allow create: if request.auth.uid != null;
-      allow update: if request.auth.uid == resource.data.userId && resource.data.userId == request.resource.userId
-      allow delete: if request.auth.uid == resource.data.userId;
     }
     match /reviews/{userId} {
       allow read, write: if true;
-      allow create: if request.auth.uid != null;
-      allow update: if request.auth.uid == resource.data.userId && resource.data.userId == request.resource.userId
-      allow delete: if request.auth.uid == resource.data.userId;
     }
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -5,7 +5,7 @@ service cloud.firestore {
       allow read, write: if true;
       allow create: if request.auth.uid != null;
       allow update: if request.auth.uid == resource.data.userId && resource.data.userId == request.resource.userId
-      allow delete: if true;
+      allow delete: if request.auth.uid == resource.data.userId;
     }
     match /companyProfile/{userId} {
       allow read, write: if true;

--- a/firestore.rules
+++ b/firestore.rules
@@ -5,25 +5,25 @@ service cloud.firestore {
       allow read, write: if true;
       allow create: if request.auth.uid != null;
       allow update: if request.auth.uid == resource.data.userId && resource.data.userId == request.resource.userId
-      allow delete: if request.auth.uid == resource.data.userId == request.auth.uid;
+      allow delete: if true;
     }
     match /companyProfile/{userId} {
       allow read, write: if true;
       allow create: if request.auth.uid != null;
       allow update: if request.auth.uid == resource.data.userId && resource.data.userId == request.resource.userId
-      allow delete: if request.auth.uid == resource.data.userId == request.auth.uid;
+      allow delete: if request.auth.uid == resource.data.userId;
     }
     match /JobPosts/{userId} {
       allow read, write: if true;
       allow create: if request.auth.uid != null;
       allow update: if request.auth.uid == resource.data.userId && resource.data.userId == request.resource.userId
-      allow delete: if request.auth.uid == resource.data.userId == request.auth.uid;
+      allow delete: if request.auth.uid == resource.data.userId;
     }
     match /reviews/{userId} {
       allow read, write: if true;
       allow create: if request.auth.uid != null;
       allow update: if request.auth.uid == resource.data.userId && resource.data.userId == request.resource.userId
-      allow delete: if request.auth.uid == resource.data.userId == request.auth.uid;
+      allow delete: if request.auth.uid == resource.data.userId;
     }
   }
 }

--- a/src/app/delete-dialog/delete-dialog.component.html
+++ b/src/app/delete-dialog/delete-dialog.component.html
@@ -3,6 +3,6 @@
   <p>削除すると元には戻せません。</p>
   <div mat-dialog-actions>
     <button mat-flat-button matDialogClose>キャンセル</button>
-    <button mat-flat-button color="warn">削除</button>
+    <button mat-flat-button color="warn" (click)="delete()">削除</button>
   </div>
 </div>

--- a/src/app/delete-dialog/delete-dialog.component.ts
+++ b/src/app/delete-dialog/delete-dialog.component.ts
@@ -17,8 +17,6 @@ export class DeleteDialogComponent implements OnInit {
   ngOnInit() {}
 
   delete() {
-    const userId = this.authService.uid;
-    this.userProfileService.deleteProfile(userId);
-    // console.log(userId);
+    this.userProfileService.deleteProfile(this.authService.uid);
   }
 }

--- a/src/app/delete-dialog/delete-dialog.component.ts
+++ b/src/app/delete-dialog/delete-dialog.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { UserProfileService } from '../service/user-profile.service';
+import { AuthService } from '../services/auth.service';
 
 @Component({
   selector: 'app-delete-dialog',
@@ -6,7 +8,17 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./delete-dialog.component.scss']
 })
 export class DeleteDialogComponent implements OnInit {
-  constructor() {}
+  userId: string;
+  constructor(
+    private userProfileService: UserProfileService,
+    private authService: AuthService
+  ) {}
 
   ngOnInit() {}
+
+  delete() {
+    const userId = this.authService.uid;
+    this.userProfileService.deleteProfile(userId);
+    // console.log(userId);
+  }
 }

--- a/src/app/mypage/mypage/mypage.component.html
+++ b/src/app/mypage/mypage/mypage.component.html
@@ -1,5 +1,8 @@
 <div class="mypage">
   <h2>マイページ</h2>
+  <p class="mypage__default-text" *ngIf="!(profile$ | async)">
+    プロフィールがありません。
+  </p>
   <div class="mypage__list" *ngIf="profile$ | async as profile">
     <dl>
       <dt>画像</dt>
@@ -42,10 +45,16 @@
       </dd>
     </dl>
   </div>
-  <div class="mypage__btn">
+  <div class="mypage__btn" *ngIf="profile$ | async as user">
     <a routerLink="/profile" mat-raised-button color="primary">編集する</a>
     <button mat-raised-button color="warn" (click)="openDeleteDialog()">
       削除する
+    </button>
+  </div>
+
+  <div class="mypage__btn" *ngIf="!(profile$ | async)">
+    <button routerLink="/profile" mat-raised-button color="primary">
+      作成する
     </button>
   </div>
 

--- a/src/app/mypage/mypage/mypage.component.html
+++ b/src/app/mypage/mypage/mypage.component.html
@@ -1,70 +1,65 @@
 <div class="mypage">
   <h2>マイページ</h2>
-  <ng-template #defaultText class="mypage__default-text">
+  <ng-container *ngIf="profile$ | async as profile; else default">
+    <div class="mypage__list">
+      <dl>
+        <dt>画像</dt>
+        <dd><img [src]="profile.photoURL" alt="" /></dd>
+
+        <dt>名前</dt>
+        <dd>{{ profile.name }}</dd>
+
+        <dt>住所</dt>
+        <dd>{{ profile.address }}</dd>
+
+        <dt>生年月日</dt>
+        <dd>
+          {{ profile.bday.year }}年{{ profile.bday.month }}月{{
+            profile.bday.day
+          }}日
+        </dd>
+
+        <dt>性別</dt>
+        <dd>{{ profile.gender }}</dd>
+
+        <dt>メールアドレス</dt>
+        <dd>{{ profile.email }}</dd>
+
+        <dt>電話番号</dt>
+        <dd>{{ profile.tel }}</dd>
+
+        <dt>学歴</dt>
+        <dd>{{ profile.belongs }},{{ profile.school }}{{ profile.state }}</dd>
+
+        <dt>資格</dt>
+        <dd>{{ profile.tagOne }}, {{ profile.tagSecond }}</dd>
+
+        <dt>勤務可能な日時</dt>
+        <dd>{{ profile.possibleDay }}</dd>
+
+        <dt>自己紹介</dt>
+        <dd>
+          {{ profile.introduce }}
+        </dd>
+      </dl>
+    </div>
+    <div class="mypage__btn">
+      <a routerLink="/profile" mat-raised-button color="primary">編集する</a>
+      <button mat-raised-button color="warn" (click)="openDeleteDialog()">
+        削除する
+      </button>
+    </div>
+  </ng-container>
+  <ng-template #default>
     <p class="mypage__default-text">
       プロフィールがありません。
     </p>
-  </ng-template>
-  <div
-    class="mypage__list"
-    *ngIf="profile$ | async as profile; else defaultText"
-  >
-    <dl>
-      <dt>画像</dt>
-      <dd><img [src]="profile.photoURL" alt="" /></dd>
-
-      <dt>名前</dt>
-      <dd>{{ profile.name }}</dd>
-
-      <dt>住所</dt>
-      <dd>{{ profile.address }}</dd>
-
-      <dt>生年月日</dt>
-      <dd>
-        {{ profile.bday.year }}年{{ profile.bday.month }}月{{
-          profile.bday.day
-        }}日
-      </dd>
-
-      <dt>性別</dt>
-      <dd>{{ profile.gender }}</dd>
-
-      <dt>メールアドレス</dt>
-      <dd>{{ profile.email }}</dd>
-
-      <dt>電話番号</dt>
-      <dd>{{ profile.tel }}</dd>
-
-      <dt>学歴</dt>
-      <dd>{{ profile.belongs }},{{ profile.school }}{{ profile.state }}</dd>
-
-      <dt>資格</dt>
-      <dd>{{ profile.tagOne }}, {{ profile.tagSecond }}</dd>
-
-      <dt>勤務可能な日時</dt>
-      <dd>{{ profile.possibleDay }}</dd>
-
-      <dt>自己紹介</dt>
-      <dd>
-        {{ profile.introduce }}
-      </dd>
-    </dl>
-  </div>
-  <div class="mypage__btn" *ngIf="profile$ | async as user; else defaultBtn">
-    <a routerLink="/profile" mat-raised-button color="primary">編集する</a>
-    <button mat-raised-button color="warn" (click)="openDeleteDialog()">
-      削除する
-    </button>
-  </div>
-
-  <ng-template #defaultBtn>
     <div class="mypage__btn">
       <button routerLink="/profile" mat-raised-button color="primary">
         作成する
       </button>
     </div>
   </ng-template>
-
   <div class="mypage__footer-item">
     <a routerLink="/plan">プラン</a>
     <a routerLink="/">企業の方はこちらから</a>

--- a/src/app/mypage/mypage/mypage.component.html
+++ b/src/app/mypage/mypage/mypage.component.html
@@ -1,9 +1,14 @@
 <div class="mypage">
   <h2>マイページ</h2>
-  <p class="mypage__default-text" *ngIf="!(profile$ | async)">
-    プロフィールがありません。
-  </p>
-  <div class="mypage__list" *ngIf="profile$ | async as profile">
+  <ng-template #defaultText class="mypage__default-text">
+    <p class="mypage__default-text">
+      プロフィールがありません。
+    </p>
+  </ng-template>
+  <div
+    class="mypage__list"
+    *ngIf="profile$ | async as profile; else defaultText"
+  >
     <dl>
       <dt>画像</dt>
       <dd><img [src]="profile.photoURL" alt="" /></dd>
@@ -45,18 +50,20 @@
       </dd>
     </dl>
   </div>
-  <div class="mypage__btn" *ngIf="profile$ | async as user">
+  <div class="mypage__btn" *ngIf="profile$ | async as user; else defaultBtn">
     <a routerLink="/profile" mat-raised-button color="primary">編集する</a>
     <button mat-raised-button color="warn" (click)="openDeleteDialog()">
       削除する
     </button>
   </div>
 
-  <div class="mypage__btn" *ngIf="!(profile$ | async)">
-    <button routerLink="/profile" mat-raised-button color="primary">
-      作成する
-    </button>
-  </div>
+  <ng-template #defaultBtn>
+    <div class="mypage__btn">
+      <button routerLink="/profile" mat-raised-button color="primary">
+        作成する
+      </button>
+    </div>
+  </ng-template>
 
   <div class="mypage__footer-item">
     <a routerLink="/plan">プラン</a>

--- a/src/app/mypage/mypage/mypage.component.scss
+++ b/src/app/mypage/mypage/mypage.component.scss
@@ -13,7 +13,7 @@
   h2 {
     font-size: 20px;
     text-align: center;
-    margin-bottom: 24px;
+    margin-bottom: 56px;
     @include pc {
       font-size: 24px;
     }
@@ -46,6 +46,13 @@
     width: 200px;
     @include pc {
       width: 300px;
+    }
+  }
+  &__default-text {
+    text-align: center;
+    font-size: 14px;
+    @include pc {
+      font-size: 16px;
     }
   }
 }

--- a/src/app/mypage/mypage/mypage.component.ts
+++ b/src/app/mypage/mypage/mypage.component.ts
@@ -12,7 +12,7 @@ import { UserProfile } from 'src/app/interfaces/profile';
   styleUrls: ['./mypage.component.scss']
 })
 export class MypageComponent implements OnInit {
-  profile$: Observable<UserProfile> = this.userProfileService.getUser(
+  profile$: Observable<UserProfile> = this.userProfileService.getProfile(
     this.authService.uid
   );
 

--- a/src/app/profile/profile/profile.component.html
+++ b/src/app/profile/profile/profile.component.html
@@ -200,22 +200,3 @@
     </button>
   </div>
 </form>
-
-<!-- <div class="submit__profile">
-  <p>名前：{{ form.value.name }}</p>
-  <p>住所：{{ form.value.address }}</p>
-  <p>
-    生年月日：{{ form.value.bday.year }}年{{ form.value.bday.month }}月{{
-      form.value.bday.day
-    }}日
-  </p>
-  <p>性別：{{ form.value.gender }}</p>
-  <p>メールアドレス：{{ form.value.email }}</p>
-  <p>電話番号：{{ form.value.tel }}</p>
-  <p>自己紹介：{{ form.value.introduce }}</p>
-  <p>
-    学歴：{{ form.value.belongs }}{{ form.value.school }}{{ form.value.state }}
-  </p>
-  <p>タグ：{{ form.value.tagOne }}、{{ form.value.tagSecond }}</p>
-  <p>勤務可能な日：{{ form.value.possibleDay }}</p>
-</div> -->

--- a/src/app/profile/profile/profile.component.ts
+++ b/src/app/profile/profile/profile.component.ts
@@ -2,9 +2,6 @@ import { Component, OnInit } from '@angular/core';
 import { FormBuilder, Validators, FormControl } from '@angular/forms';
 import { UserProfileService } from 'src/app/service/user-profile.service';
 import { AuthService } from 'src/app/services/auth.service';
-import { Observable } from 'rxjs';
-import { UserProfile } from 'src/app/interfaces/profile';
-
 @Component({
   selector: 'app-profile',
   templateUrl: './profile.component.html',

--- a/src/app/profile/profile/profile.component.ts
+++ b/src/app/profile/profile/profile.component.ts
@@ -108,11 +108,13 @@ export class ProfileComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.userProfileService.getUser(this.authService.uid).subscribe(profile => {
-      if (profile) {
-        this.form.patchValue(profile);
-      }
-    });
+    this.userProfileService
+      .getProfile(this.authService.uid)
+      .subscribe(profile => {
+        if (profile) {
+          this.form.patchValue(profile);
+        }
+      });
   }
 
   setAvatar(event) {

--- a/src/app/service/user-profile.service.ts
+++ b/src/app/service/user-profile.service.ts
@@ -47,17 +47,14 @@ export class UserProfileService {
   }
 
   private async updateAvatar(userId: string, file: File) {
-    console.log(userId);
     const result = await this.storage.ref(`userProfile/${userId}`).put(file);
     const photoURL = await result.ref.getDownloadURL();
     this.db.doc(`userProfile/${userId}`).update({
       photoURL
     });
-    console.log(photoURL);
   }
 
   deleteProfile(userId: string): Promise<void> {
-    console.log(userId);
     return this.db
       .doc(`userProfile/${userId}`)
       .delete()

--- a/src/app/service/user-profile.service.ts
+++ b/src/app/service/user-profile.service.ts
@@ -6,6 +6,7 @@ import { Router } from '@angular/router';
 import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 import { AngularFireStorage } from '@angular/fire/storage';
+import { AuthService } from '../services/auth.service';
 
 @Injectable({
   providedIn: 'root'
@@ -15,39 +16,54 @@ export class UserProfileService {
     private db: AngularFirestore,
     private snackBar: MatSnackBar,
     private router: Router,
-    private storage: AngularFireStorage
+    private storage: AngularFireStorage,
+    private authService: AuthService
   ) {}
 
-  createUser(profile: UserProfile, avatarImage?: File) {
+  createUser(
+    profile: Omit<UserProfile, 'userId'>,
+    avatarImage?: File
+  ): Promise<void> {
+    const userId = this.authService.uid;
     return this.db
-      .doc(`userProfile/${profile.userId}`)
-      .set(profile)
+      .doc(`userProfile/${userId}`)
+      .set({ userId, ...profile })
       .then(() => {
         this.snackBar.open('userを作成しました。', null, {
           duration: 2000
         });
         if (avatarImage) {
-          this.updateAvatar(profile.userId, avatarImage);
+          this.updateAvatar(userId, avatarImage);
         }
         this.router.navigateByUrl('/mypage');
       });
   }
-  getUser(userId: string): Observable<UserProfile> {
-    return this.db
-      .collection<UserProfile>('userProfile', ref =>
-        ref.where('userId', '==', userId)
-      )
-      .valueChanges()
-      .pipe(
-        map(userProfile => {
-          if (userProfile.length) {
-            return userProfile[0];
-          } else {
-            return null;
-          }
-        })
-      );
+
+  getProfile(userId: string): Observable<UserProfile> {
+    return this.db.doc<UserProfile>(`userProfile/${userId}`).valueChanges();
   }
+
+  getProfiles(userId: string): Observable<UserProfile[]> {
+    return this.db.collection<UserProfile>(`userProfile`).valueChanges();
+  }
+
+  // getUser(userId: string): Observable<UserProfile> {
+  //   return this.db
+  //     .collection<UserProfile>('userProfile', ref =>
+  //       ref.where('userId', '==', userId)
+  //     )
+  //     .valueChanges()
+  //     .pipe(
+  //       map(userProfile => {
+  //         if (userProfile.length) {
+  //           return userProfile[0];
+  //         } else {
+  //           return null;
+  //         }
+  //       })
+  //     );
+  // }
+
   private async updateAvatar(userId: string, file: File) {
     console.log(userId);
     const result = await this.storage.ref(`userProfile/${userId}`).put(file);
@@ -56,5 +72,10 @@ export class UserProfileService {
       photoURL
     });
     console.log(photoURL);
+  }
+
+  deleteProfile(userId: string): Promise<void> {
+    console.log(userId);
+    return this.db.doc(`userProfile'/${userId}`).delete();
   }
 }

--- a/src/app/service/user-profile.service.ts
+++ b/src/app/service/user-profile.service.ts
@@ -3,7 +3,6 @@ import { AngularFirestore } from '@angular/fire/firestore';
 import { UserProfile } from '../interfaces/profile';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
-import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 import { AngularFireStorage } from '@angular/fire/storage';
 import { AuthService } from '../services/auth.service';
@@ -30,7 +29,7 @@ export class UserProfileService {
       .set({ userId, ...profile })
       .then(() => {
         this.snackBar.open('userを作成しました。', null, {
-          duration: 2000
+          duration: 3000
         });
         if (avatarImage) {
           this.updateAvatar(userId, avatarImage);
@@ -47,23 +46,6 @@ export class UserProfileService {
     return this.db.collection<UserProfile>(`userProfile`).valueChanges();
   }
 
-  // getUser(userId: string): Observable<UserProfile> {
-  //   return this.db
-  //     .collection<UserProfile>('userProfile', ref =>
-  //       ref.where('userId', '==', userId)
-  //     )
-  //     .valueChanges()
-  //     .pipe(
-  //       map(userProfile => {
-  //         if (userProfile.length) {
-  //           return userProfile[0];
-  //         } else {
-  //           return null;
-  //         }
-  //       })
-  //     );
-  // }
-
   private async updateAvatar(userId: string, file: File) {
     console.log(userId);
     const result = await this.storage.ref(`userProfile/${userId}`).put(file);
@@ -76,6 +58,13 @@ export class UserProfileService {
 
   deleteProfile(userId: string): Promise<void> {
     console.log(userId);
-    return this.db.doc(`userProfile'/${userId}`).delete();
+    return this.db
+      .doc(`userProfile/${userId}`)
+      .delete()
+      .then(() => {
+        this.snackBar.open('プロフィールを削除しました。', null, {
+          duration: 3000
+        });
+      });
   }
 }


### PR DESCRIPTION
- ユーザープロフィールを削除ボタンを押すと削除できるようにしました。
- マイページでプロフィールがない時にはdefault textとプロフィール作成ボタンを表示。

レビューよろしくお願いいたします。
