### PR TITLE
Feature/new122 企業側Firestore削除、メソッド分割

### DIFF
--- a/src/app/company-profile/company-profile/company-profile.component.html
+++ b/src/app/company-profile/company-profile/company-profile.component.html
@@ -1,35 +1,46 @@
 <div class="company-profile">
   <h2>企業側プロフィール</h2>
-  <div class="company-profile__list" *ngIf="profile$ | async as profile">
-    <dl>
-      <dt>会社名</dt>
-      <dd>{{ profile.name }}</dd>
+  <ng-container *ngIf="profile$ | async as profile; else default">
+    <div class="company-profile__list">
+      <dl>
+        <dt>会社名</dt>
+        <dd>{{ profile.name }}</dd>
 
-      <dt>部署名</dt>
-      <dd>{{ profile.department }}</dd>
+        <dt>部署名</dt>
+        <dd>{{ profile.department }}</dd>
 
-      <dt>お名前</dt>
-      <dd>{{ profile.firstName }} {{ profile.lastName }}</dd>
+        <dt>お名前</dt>
+        <dd>{{ profile.firstName }} {{ profile.lastName }}</dd>
 
-      <dt>電話番号</dt>
-      <dd>{{ profile.tel }}</dd>
+        <dt>電話番号</dt>
+        <dd>{{ profile.tel }}</dd>
 
-      <dt>メールアドレス</dt>
-      <dd>{{ profile.email }}</dd>
+        <dt>メールアドレス</dt>
+        <dd>{{ profile.email }}</dd>
 
-      <dt>パスワード</dt>
-      <dd>{{ profile.password }}</dd>
-    </dl>
-  </div>
-  <div class="company-profile__btn">
-    <a routerLink="/companySideForm" mat-raised-button color="primary"
-      >編集する</a
-    >
-    <button mat-raised-button color="warn" (click)="openDeleteDialog()">
-      削除する
-    </button>
-  </div>
-
+        <dt>パスワード</dt>
+        <dd>{{ profile.password }}</dd>
+      </dl>
+    </div>
+    <div class="company-profile__btn">
+      <a routerLink="/companySideForm" mat-raised-button color="primary"
+        >編集する</a
+      >
+      <button mat-raised-button color="warn" (click)="openDeleteDialog()">
+        削除する
+      </button>
+    </div>
+  </ng-container>
+  <ng-template #default>
+    <p class="company-profile__default-text">
+      プロフィールがありません。
+    </p>
+    <div class="company-profile__btn">
+      <button routerLink="/companySideForm" mat-raised-button color="primary">
+        作成する
+      </button>
+    </div>
+  </ng-template>
   <div class="company-profile__footer-item">
     <a routerLink="/plan">プラン</a>
     <a routerLink="/">企業の方はこちらから</a>

--- a/src/app/company-profile/company-profile/company-profile.component.scss
+++ b/src/app/company-profile/company-profile/company-profile.component.scss
@@ -42,6 +42,13 @@
       }
     }
   }
+  &__default-text {
+    text-align: center;
+    font-size: 14px;
+    @include pc {
+      font-size: 16px;
+    }
+  }
 }
 
 dl {

--- a/src/app/company-profile/company-profile/company-profile.component.ts
+++ b/src/app/company-profile/company-profile/company-profile.component.ts
@@ -22,7 +22,14 @@ export class CompanyProfileComponent implements OnInit {
   ) {}
 
   openDeleteDialog() {
-    this.dialog.open(DeleteDialogComponent);
+    this.dialog
+      .open(DeleteDialogComponent)
+      .afterClosed()
+      .subscribe(status => {
+        if (status) {
+          this.companyProfileSurvice.deleteCompanyUser(this.authService.uid);
+        }
+      });
   }
 
   ngOnInit() {}

--- a/src/app/delete-dialog/delete-dialog.component.html
+++ b/src/app/delete-dialog/delete-dialog.component.html
@@ -3,6 +3,6 @@
   <p>削除すると元には戻せません。</p>
   <div mat-dialog-actions>
     <button mat-flat-button matDialogClose>キャンセル</button>
-    <button mat-flat-button color="warn" (click)="delete()">削除</button>
+    <button mat-flat-button color="warn" [matDialogClose]="true">削除</button>
   </div>
 </div>

--- a/src/app/delete-dialog/delete-dialog.component.ts
+++ b/src/app/delete-dialog/delete-dialog.component.ts
@@ -15,8 +15,4 @@ export class DeleteDialogComponent implements OnInit {
   ) {}
 
   ngOnInit() {}
-
-  delete() {
-    this.userProfileService.deleteProfile(this.authService.uid);
-  }
 }

--- a/src/app/mypage/mypage/mypage.component.ts
+++ b/src/app/mypage/mypage/mypage.component.ts
@@ -23,7 +23,14 @@ export class MypageComponent implements OnInit {
   ) {}
 
   openDeleteDialog() {
-    this.dialog.open(DeleteDialogComponent);
+    this.dialog
+      .open(DeleteDialogComponent)
+      .afterClosed()
+      .subscribe(status => {
+        if (status) {
+          this.userProfileService.deleteProfile(this.authService.uid);
+        }
+      });
   }
 
   ngOnInit() {}


### PR DESCRIPTION
- 企業側のFirestoreのプロフィール削除
- プロフィールが存在しない時はdefaultのテキストと作成ボタン配置
- dialogのdelete関数をコンポーネントごとに分割


レビューよろしくお願いいたします！！