### PR TITLE
無料プランのボタンdisabled追加、ボタン文言追加 

### DIFF
--- a/src/app/plan/plan/plan.component.html
+++ b/src/app/plan/plan/plan.component.html
@@ -8,7 +8,12 @@
           <span>¥0</span>
           <span>（¥0/月）</span>
           <div class="plan__register-btn">
-            <button mat-flat-button disabled *ngIf="subscriptionID">
+            <button
+              mat-flat-button
+              color="primary"
+              *ngIf="subscriptionID"
+              (click)="stripeDialog()"
+            >
               登録
             </button>
             <button mat-flat-button disabled *ngIf="!subscriptionID">

--- a/src/app/plan/plan/plan.component.html
+++ b/src/app/plan/plan/plan.component.html
@@ -8,7 +8,12 @@
           <span>¥0</span>
           <span>（¥0/月）</span>
           <div class="plan__register-btn">
-            <button mat-flat-button color="primary">登録</button>
+            <button mat-flat-button disabled *ngIf="subscriptionID">
+              登録
+            </button>
+            <button mat-flat-button disabled *ngIf="!subscriptionID">
+              登録中
+            </button>
           </div>
         </div>
 

--- a/src/app/stripe/stripe/stripe.component.html
+++ b/src/app/stripe/stripe/stripe.component.html
@@ -22,7 +22,7 @@
   <ng-container *ngIf="subscriptionID">
     <div class="subscription">
       <h2>プレミアムプラン(¥1,200/月)</h2>
-      <p>プレミアムプランを解約しますか？？</p>
+      <p>プレミアムプランを解約して無料プランに戻しますか？？</p>
       <p>
         解約すると月額購読は中止されます。
       </p>


### PR DESCRIPTION
## 該当issue
- #236 プラン登録押しても何も起きない
### 実装内容
- プランの初期状態は無料プランの方に登録中
- 有料プランに変更すると無料プランの文言が登録に変わる。

### 変更点の実際の挙動
#### 初期状態
<img width="1034" alt="スクリーンショット 2020-03-24 20 52 42" src="https://user-images.githubusercontent.com/49673112/77424034-d4180780-6e13-11ea-8b98-a5feb2b39257.png">

#### 有料プラン登録後
<img width="1008" alt="スクリーンショット 2020-03-24 20 52 19" src="https://user-images.githubusercontent.com/49673112/77424147-f6aa2080-6e13-11ea-8469-c8c7cd2d0e34.png">

ご確認よろしくお願い致します。