### PR TITLE
有料プラン登録画面のボタンの文言修正 #238

### DIFF
--- a/src/app/stripe/stripe/stripe.component.html
+++ b/src/app/stripe/stripe/stripe.component.html
@@ -14,7 +14,7 @@
           [matDialogClose]="true"
           (click)="startSubscribe()"
         >
-          購入する
+          登録する
         </button>
       </div>
     </div>


### PR DESCRIPTION
## 該当issue
- #238 文言修正
### 実装内容
- 有料プラン登録画面のボタンの文言修正 「購入する」➡️　「登録する」に変更。

### 変更点の実際の挙動

<img width="658" alt="スクリーンショット 2020-03-24 21 30 26" src="https://user-images.githubusercontent.com/49673112/77425973-eba4bf80-6e16-11ea-90ea-b5e821968fab.png">

ご確認よろしくお願い致します。