### PR TITLE
headerのmenu名変更 #237

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -35,13 +35,13 @@
           <ng-container *ngIf="userLoginStatus">
             <button mat-menu-item routerLink="/mypage">
               <mat-icon>person</mat-icon>
-              <span>マイページ</span>
+              <span>プロフィール</span>
             </button>
           </ng-container>
           <ng-container *ngIf="companyLoginStatus">
             <button mat-menu-item routerLink="/companyProfile">
               <mat-icon>person</mat-icon>
-              <span>マイページ</span>
+              <span>プロフィール</span>
             </button>
           </ng-container>
           <ng-container *ngIf="companyLoginStatus">


### PR DESCRIPTION
## 該当issue
- #237 マイページと自社求人がメニューに表示されている
### 実装内容
- headerのメニュー名を変更

### 変更点の実際の挙動
変更前
<img width="343" alt="スクリーンショット 2020-03-24 21 46 39" src="https://user-images.githubusercontent.com/49673112/77427710-2fe58f00-6e1a-11ea-8996-3071599221f3.png">

変更後
<img width="148" alt="スクリーンショット 2020-03-24 21 55 45" src="https://user-images.githubusercontent.com/49673112/77427762-468be600-6e1a-11ea-8d42-c1a379263d88.png">

ご確認よろしくお願い致します。
