### PR TITLE
求人カードにpadding追加 #242

### DIFF
--- a/src/styles/_job-post.scss
+++ b/src/styles/_job-post.scss
@@ -53,7 +53,7 @@
     color: #3c4043;
   }
   &__content {
-    padding: 0 8px;
+    padding: 16px;
     flex: 1;
   }
   a {


### PR DESCRIPTION
## 該当issue
- #242 カードスタイル調整
### 実装内容
- 求人カードにpadding: 16px追加

### 変更点の実際の挙動

<img width="397" alt="スクリーンショット 2020-03-24 22 00 18" src="https://user-images.githubusercontent.com/49673112/77428189-14c74f00-6e1b-11ea-9874-991f21946121.png">

ご確認よろしくお願い致します。