### PR TITLE
GoogleMap幅修正 #245

### DIFF
--- a/src/app/detail/detail/detail.component.scss
+++ b/src/app/detail/detail/detail.component.scss
@@ -129,13 +129,13 @@
     box-sizing: border-box;
   }
   iframe {
-    width: 180px;
+    width: 100%;
     height: auto;
-    @include tab {
-      width: 300px;
+    @include mobile {
+      width: 80%;
     }
     @include pc {
-      width: 250px;
+      width: 100%;
     }
   }
   &__default-text {


### PR DESCRIPTION
## 該当issue
- #245 GoogleMapの表示崩れ
### 実装内容
- GoogleMap幅修正しました。

### 変更点の実際の挙動

[![Image from Gyazo](https://i.gyazo.com/d3bbf42c1d0d948fc5d9e04e569d277c.gif)](https://gyazo.com/d3bbf42c1d0d948fc5d9e04e569d277c)

ご確認よろしくお願い致します。