### PR TITLE
ログイン後headerのmenuにクリックできないようにする実装 #248

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -18,11 +18,13 @@
         >
           <mat-icon>add</mat-icon>
         </button>
-        <div class="header__user-icon">
-          <button mat-icon-button [matMenuTriggerFor]="menu">
-            <img *ngIf="user$ | async as user" [src]="user.photoURL" alt="" />
-          </button>
-        </div>
+        <ng-container *ngIf="user$ | async as user">
+          <div class="header__user-icon">
+            <button mat-icon-button [matMenuTriggerFor]="menu">
+              <img [src]="user.photoURL" alt="" />
+            </button>
+          </div>
+        </ng-container>
         <mat-menu #menu="matMenu">
           <button mat-menu-item *ngIf="user$ | async" (click)="logout()">
             <mat-icon>input</mat-icon>


### PR DESCRIPTION
## 該当issue
- #248 ログアウト後もアイコンボタンが表示される
### 実装内容
- ログアウト後にメニューが非表示になっていてもクリックできてしまっていたので、クリックできない実装にしました。

### 変更点の実際の挙動
- ログイン後はクリックしても何も起きません。
[![Image from Gyazo](https://i.gyazo.com/4e8b0866de0985ae97623fef11473569.gif)](https://gyazo.com/4e8b0866de0985ae97623fef11473569)

ご確認よろしくお願い致します。