### PR TITLE
グリッド(margin-bottm)縮小#284

### DIFF
--- a/src/styles/_job-post.scss
+++ b/src/styles/_job-post.scss
@@ -15,17 +15,17 @@
   &__card {
     @include mat-elevation(3);
     width: 100%;
-    margin-bottom: 16px;
+    margin-bottom: 8px;
     padding-bottom: 16px;
     border-radius: 5px;
     box-sizing: border-box;
     display: flex;
     flex-flow: column;
     @include tab {
-      margin: 0 auto 32px;
+      margin: 0 auto 8px;
     }
     @include pc {
-      margin-bottom: 56px;
+      margin-bottom: 8px;
       padding-bottom: 40px;
       transition: 0.5s;
       &:hover {

--- a/src/styles/_job-post.scss
+++ b/src/styles/_job-post.scss
@@ -15,17 +15,16 @@
   &__card {
     @include mat-elevation(3);
     width: 100%;
-    margin-bottom: 8px;
+    margin-bottom: 16px;
     padding-bottom: 16px;
     border-radius: 5px;
     box-sizing: border-box;
     display: flex;
     flex-flow: column;
     @include tab {
-      margin: 0 auto 8px;
+      margin: 0 auto;
     }
     @include pc {
-      margin-bottom: 8px;
       padding-bottom: 40px;
       transition: 0.5s;
       &:hover {


### PR DESCRIPTION
## 該当issue
- #284 グリッドの幅を検討する
### 実装内容
- cardのmargin-bottomを縮小しました。

### 変更点の実際の挙動

<img width="1188" alt="スクリーンショット 2020-03-27 13 02 27" src="https://user-images.githubusercontent.com/49673112/77720485-69d9af80-702b-11ea-9dd1-275a9283dde8.png">


ご確認よろしくお願い致します。