### PR TITLE
header/スタイル壊れているところの修正 #301

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -14,9 +14,6 @@
     @include tab {
       margin-top: 64px;
     }
-    @include pc {
-      margin-top: 80px;
-    }
   }
 }
 .mat-drawer-content {

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -2,6 +2,7 @@
 @import '~@angular/material/theming';
 
 .header {
+  color: #333333;
   background-color: #fff;
   display: flex;
   justify-content: space-between;
@@ -15,10 +16,6 @@
   @include mat-elevation(1);
   @include pc {
     padding: 0 32px;
-  }
-  a {
-    color: #fff;
-    text-decoration: none;
   }
   p {
     font-size: 24px;
@@ -42,7 +39,6 @@
       align-items: center;
     }
     button {
-      color: #fff;
     }
   }
   &__nav-item {
@@ -57,7 +53,6 @@
       span {
         display: inline-flex;
         vertical-align: middle;
-        color: #fff;
       }
     }
     img {
@@ -78,6 +73,7 @@
     text-align: center;
     line-height: 1;
     img {
+      outline: none;
       cursor: pointer;
       width: 130px;
       @include pc {


### PR DESCRIPTION
## 該当issue
- #301 headerデザイン修正
### 実装内容
- headerテキストカラー変更
- サイドバーmargin変更

### 変更点の実際の挙動

<img width="1438" alt="スクリーンショット 2020-04-02 16 55 11" src="https://user-images.githubusercontent.com/49673112/78224017-c264ed00-7502-11ea-8eef-47fda3b8d28f.png">


ご確認よろしくお願い致します。