### PR TITLE
ログインボタンheaderに配置/ ログインダイアログ追加

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -41,6 +41,7 @@ import { SearchResultComponent } from './search-result/search-result.component';
 // ストライプ
 import { NgxStripeModule } from 'ngx-stripe';
 import { PaymentComponent } from './stripe/payment/payment.component';
+import { AuthDialogComponent } from './auth-dialog/auth-dialog.component';
 @NgModule({
   declarations: [
     AppComponent,
@@ -53,7 +54,8 @@ import { PaymentComponent } from './stripe/payment/payment.component';
     SearchResultComponent,
     SearchInputComponent,
     SearchComponent,
-    FooterComponent
+    FooterComponent,
+    AuthDialogComponent
   ],
   imports: [
     BrowserModule,
@@ -89,7 +91,8 @@ import { PaymentComponent } from './stripe/payment/payment.component';
     DeleteDialogComponent,
     ProfileDialogComponent,
     StripeComponent,
-    PaymentComponent
+    PaymentComponent,
+    AuthDialogComponent
   ]
 })
 export class AppModule {}

--- a/src/app/auth-dialog/auth-dialog.component.html
+++ b/src/app/auth-dialog/auth-dialog.component.html
@@ -1,0 +1,22 @@
+<div class="auth-dialog">
+  <h2 matDialogTitle>ログイン</h2>
+  <div mat-dialog-actions>
+    <div class="auth-dialog__user">
+      <button mat-stroked-button [matDialogClose]="true" (click)="loginUser()">
+        <img src="assets/google.png" width="30" alt="" />
+        Googleでログインする
+      </button>
+      <button mat-flat-button color="warn" matDialogClose>戻る</button>
+    </div>
+    <div class="auth-dialog__another">
+      <button
+        mat-button
+        color="primary"
+        [matDialogClose]="true"
+        (click)="loginCompany()"
+      >
+        企業の方はこちらへ
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/app/auth-dialog/auth-dialog.component.scss
+++ b/src/app/auth-dialog/auth-dialog.component.scss
@@ -1,0 +1,30 @@
+@import 'mixins';
+
+.auth-dialog {
+  max-width: 1000px;
+  h2 {
+    font-size: 24px;
+    border-bottom: 1px solid #d8d9db;
+    padding-bottom: 16px;
+  }
+  &__user {
+    margin: 0 auto 40px;
+    width: 100%;
+    @include tab {
+      width: 70%;
+    }
+    button {
+      padding: 8px 16px;
+      margin-bottom: 16px;
+      width: 100%;
+    }
+  }
+  &__another {
+    width: 100%;
+  }
+}
+
+.mat-dialog-actions .mat-button-base,
+.mat-button-base {
+  margin-left: 0;
+}

--- a/src/app/auth-dialog/auth-dialog.component.spec.ts
+++ b/src/app/auth-dialog/auth-dialog.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AuthDialogComponent } from './auth-dialog.component';
+
+describe('AuthDialogComponent', () => {
+  let component: AuthDialogComponent;
+  let fixture: ComponentFixture<AuthDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [AuthDialogComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AuthDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/auth-dialog/auth-dialog.component.ts
+++ b/src/app/auth-dialog/auth-dialog.component.ts
@@ -1,0 +1,25 @@
+import { Component, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material';
+import { AuthService } from '../services/auth.service';
+
+@Component({
+  selector: 'app-auth-dialog',
+  templateUrl: './auth-dialog.component.html',
+  styleUrls: ['./auth-dialog.component.scss']
+})
+export class AuthDialogComponent implements OnInit {
+  userLoginStatus: boolean;
+  companyLoginStatus: boolean;
+
+  constructor(private authService: AuthService) {}
+
+  ngOnInit() {}
+
+  loginUser() {
+    this.authService.loginUser();
+  }
+
+  loginCompany() {
+    this.authService.loginCompany();
+  }
+}

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -66,12 +66,8 @@
       </div>
       <ng-container *ngIf="!(user$ | async) && searchNone()">
         <div class="header-auth">
-          <button (click)="loginUser()" mat-raised-button color="basic">
+          <button (click)="authDialog()" mat-raised-button color="basic">
             <span>ログイン</span>
-            <i class="material-icons">person</i>
-          </button>
-          <button (click)="loginCompany()" mat-raised-button color="accent">
-            企業方はこちら
           </button>
         </div>
       </ng-container>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,14 +1,22 @@
-import { Component, OnInit, Output, EventEmitter } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  Output,
+  EventEmitter,
+  DoCheck
+} from '@angular/core';
 import { AuthService } from '../services/auth.service';
 import { searchClient } from '../../environments/environment';
 import { ActivatedRoute, Router } from '@angular/router';
+import { MatDialog } from '@angular/material';
+import { AuthDialogComponent } from '../auth-dialog/auth-dialog.component';
 
 @Component({
   selector: 'app-header',
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.scss']
 })
-export class HeaderComponent implements OnInit {
+export class HeaderComponent implements OnInit, DoCheck {
   uid: string;
   userLoginStatus: boolean;
   companyLoginStatus: boolean;
@@ -37,7 +45,8 @@ export class HeaderComponent implements OnInit {
   constructor(
     private authService: AuthService,
     private route: ActivatedRoute,
-    private router: Router
+    private router: Router,
+    private dialog: MatDialog
   ) {
     this.route.queryParamMap.subscribe(map => {
       this.inputParams.query = map.get('q');
@@ -48,6 +57,10 @@ export class HeaderComponent implements OnInit {
     this.loginToggle();
   }
 
+  ngDoCheck() {
+    this.loginToggle();
+  }
+
   loginToggle() {
     const status = localStorage.getItem('Status');
     if (status === 'User') {
@@ -55,18 +68,6 @@ export class HeaderComponent implements OnInit {
     } else if (status === 'Company') {
       this.companyLoginStatus = true;
     }
-  }
-
-  loginUser() {
-    this.authService.loginUser();
-    localStorage.setItem('Status', 'User');
-    this.userLoginStatus = true;
-  }
-
-  loginCompany() {
-    this.authService.loginCompany();
-    localStorage.setItem('Status', 'Company');
-    this.companyLoginStatus = true;
   }
 
   logout() {
@@ -89,5 +90,11 @@ export class HeaderComponent implements OnInit {
   }
   notSearch() {
     this.display = false;
+  }
+
+  authDialog() {
+    this.dialog.open(AuthDialogComponent, {
+      autoFocus: false
+    });
   }
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -15,6 +15,8 @@ export class AuthService {
   afUser$: Observable<User> = this.afAuth.user;
   uid: string;
   displayName: string;
+  userLoginStatus: boolean;
+  companyLoginStatus: boolean;
 
   constructor(
     private afAuth: AngularFireAuth,
@@ -38,6 +40,8 @@ export class AuthService {
           status: 'user'
         };
         this.db.doc(`users/${result.user.uid}`).set(userData);
+        localStorage.setItem('Status', 'User');
+        this.userLoginStatus = true;
         this.snackBar.open('ようこそTokyo biteへ!', null, {
           duration: 2000
         });
@@ -77,6 +81,8 @@ export class AuthService {
           status: 'company'
         };
         this.db.doc(`companys/${result.user.uid}`).set(companyData);
+        localStorage.setItem('Status', 'Company');
+        this.companyLoginStatus = true;
         this.snackBar.open('企業側としてログインしました。', null, {
           duration: 2000
         });


### PR DESCRIPTION
## 該当issue
- #276 ログインボタンをheaderに置く
### 実装内容
- ログインボタンを headerに配置
- ログインダイアログ追加
- ダイアログでのログイン状態をheaderのmenuに反映

### 変更点の実際の挙動

<img width="855" alt="スクリーンショット 2020-04-03 15 16 06" src="https://user-images.githubusercontent.com/49673112/78330489-09b0b380-75bf-11ea-9bf4-307803226c21.png">

ご確認よろしくお願い致します。

