### PR TITLE
退会時にもlocalStorage削除で求人作成ボタンを非表示にする #263

### DIFF
--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -67,6 +67,9 @@ export class HeaderComponent implements OnInit, DoCheck {
       this.userLoginStatus = true;
     } else if (status === 'Company') {
       this.companyLoginStatus = true;
+    } else {
+      this.userLoginStatus = false;
+      this.companyLoginStatus = false;
     }
   }
 

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -107,6 +107,9 @@ export class AuthService {
     return this.afAuth.auth.currentUser
       .delete()
       .then(() => {
+        localStorage.removeItem('Status');
+        this.userLoginStatus = false;
+        this.companyLoginStatus = false;
         this.router.navigateByUrl('/');
         this.snackbar.open('ご利用ありがとうございました。', null, {
           duration: 3000


### PR DESCRIPTION
## 該当issue
- #263 未ログイン時も求人作成ボタンが表示されている
### 実装内容
- 退会後も求人作成ボタンが表示されていたので、退会時にもlocalStorageの値を削除しました。

### 変更点の実際の挙動

[![Image from Gyazo](https://i.gyazo.com/bdfdd3d3cf1a5868a00f519a2a8e40a4.gif)](https://gyazo.com/bdfdd3d3cf1a5868a00f519a2a8e40a4)


ご確認よろしくお願い致します。