### PR TITLE
決済履歴追加 #271

### DIFF
--- a/src/app/plan/plan/plan.component.html
+++ b/src/app/plan/plan/plan.component.html
@@ -77,6 +77,15 @@
             サービスではクレジットカード情報を保持しないので漏洩の心配はありません。
           </li>
         </ol>
+        <div class="plan__payment">
+          <h4>決済情報</h4>
+          <ng-container *ngIf="planID$ | async; else free">
+            <p>有料プラン開始日:{{ startedAt.toDate() | date: 'yyy/MM/dd' }}</p>
+          </ng-container>
+          <ng-template #free>
+            <p>決済情報はありません。</p>
+          </ng-template>
+        </div>
       </div>
     </mat-tab>
     <mat-tab label="退会">

--- a/src/app/plan/plan/plan.component.scss
+++ b/src/app/plan/plan/plan.component.scss
@@ -166,6 +166,17 @@
       margin-bottom: 8px;
     }
   }
+  h4 {
+    text-align: center;
+    font-size: 20px;
+    margin: 0 0 32px;
+    @include pc {
+      font-size: 24px;
+    }
+  }
+  &__payment {
+    margin: 80px 0;
+  }
 }
 
 button {

--- a/src/app/plan/plan/plan.component.ts
+++ b/src/app/plan/plan/plan.component.ts
@@ -5,9 +5,6 @@ import { FeeService } from 'src/app/services/fee.service';
 import { PaymentComponent } from 'src/app/stripe/payment/payment.component';
 import { AuthService } from 'src/app/services/auth.service';
 import { DeleteDialogComponent } from 'src/app/delete-dialog/delete-dialog.component';
-import { UserProfileService } from 'src/app/services/user-profile.service';
-import { MatSnackBar } from '@angular/material/snack-bar';
-import { CompanyProfileService } from 'src/app/services/company-profile.service';
 import { DrawerService } from 'src/app/services/drawer.service';
 
 @Component({
@@ -22,10 +19,12 @@ export class PlanComponent implements OnInit {
   customerId: string;
   cardName: string;
   amex: string;
+  startedAt: string;
   card$ = this.feeService.getCard(this.authServie.uid);
   planID$ = this.feeService.getCustomer().subscribe((plan: any) => {
     this.subscriptionID = plan.subscriptionId;
     this.customerId = plan.customerId;
+    this.startedAt = plan.startedAt;
     if (this.customerId) {
       this.text = true;
     } else {
@@ -39,9 +38,6 @@ export class PlanComponent implements OnInit {
     private authServie: AuthService,
     private dialog: MatDialog,
     private authService: AuthService,
-    private userProfileService: UserProfileService,
-    private companyProfileSurvice: CompanyProfileService,
-    private snackbar: MatSnackBar,
     private drawerService: DrawerService
   ) {
     this.drawerService.open();


### PR DESCRIPTION
## 該当issue
- #271 stripe/課金開始日時を記録しておく
### 実装内容
- 決済情報を追加
- サブスク開始日時を記録
- していなければ「決済情報はありません」追加

### 変更点の実際の挙動

<img width="308" alt="スクリーンショット 2020-04-07 14 50 46" src="https://user-images.githubusercontent.com/49673112/78635029-3971fb00-78e0-11ea-99d2-9461f50f4509.png">
<img width="759" alt="スクリーンショット 2020-04-07 14 22 48" src="https://user-images.githubusercontent.com/49673112/78635041-3ecf4580-78e0-11ea-8698-8c90d486fa8f.png">


ご確認よろしくお願い致します。

