### PR TITLE
Footer 修正 #330

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -42,7 +42,7 @@
       <main class="content">
         <router-outlet></router-outlet>
       </main>
+      <app-footer></app-footer>
     </mat-drawer-content>
   </mat-drawer-container>
-  <app-footer></app-footer>
 </div>


### PR DESCRIPTION
## 該当issue
- #330 Footer/修正
### 実装内容
- サイドナビ開閉時にFooterが前に出てきてしまっていたバグの修正
変更前
<img width="320" alt="スクリーンショット 2020-04-14 12 26 31" src="https://user-images.githubusercontent.com/49673112/79183288-02ee3000-7e4c-11ea-93bc-fae20dc5e341.png">


### 変更点の実際の挙動

<img width="325" alt="スクリーンショット 2020-04-14 12 29 27" src="https://user-images.githubusercontent.com/49673112/79183292-07b2e400-7e4c-11ea-8aa8-7db6fa6ce4bb.png">


ご確認よろしくお願い致します。

