### PR TITLE
grid幅スタイル調整 #332

### DIFF
--- a/src/styles/_job-post.scss
+++ b/src/styles/_job-post.scss
@@ -6,10 +6,16 @@
   @include tab {
     display: grid;
     gap: 16px;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fill, 360px);
+    margin: 0 auto 80px;
   }
   @include pc {
     margin: 0 auto 80px;
+    gap: 24px;
+    justify-content: center;
+  }
+  @include pclarg {
+    justify-content: space-between;
   }
   &__card {
     @include mat-elevation(3);
@@ -22,10 +28,9 @@
     display: flex;
     flex-flow: column;
     @include tab {
-      margin: 0 auto;
+      margin: 0;
     }
     @include pc {
-      margin-bottom: 56px;
       transition: 0.7s;
       &:hover {
         @include mat-elevation(12);


### PR DESCRIPTION
## 該当issue
- #332 (card) Gridの幅修正
### 実装内容
- cardの幅を調整しました。

変更前
<img width="1175" alt="スクリーンショット 2020-04-14 13 39 52" src="https://user-images.githubusercontent.com/49673112/79189642-3f765780-7e5d-11ea-8d43-230dcd6e5e28.png">


### 変更点の実際の挙動

<img width="1206" alt="スクリーンショット 2020-04-14 14 20 27" src="https://user-images.githubusercontent.com/49673112/79189659-4bfab000-7e5d-11ea-9411-91ea2bb8f1dd.png">


ご確認よろしくお願い致します。

