### PR TITLE
投稿数に応じて処理分岐 #310

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,7 +1,7 @@
 <header>
   <mat-toolbar class="header" color="primary">
     <div class="header__title">
-      <button mat-icon-button aria-label="メニュー" (click)="sidenav.toggle()">
+      <button mat-icon-button (click)="sidenav.toggle()">
         <mat-icon>menu</mat-icon>
       </button>
       <img src="assets/logo.png" alt="" routerLink="/" />
@@ -10,7 +10,6 @@
       <div class="header__nav-item">
         <button
           mat-icon-button
-          aria-label="求人検索する"
           matTooltip="求人検索する"
           *ngIf="searchIcon()"
           (click)="isSearch()"
@@ -19,74 +18,47 @@
         </button>
         <button
           mat-icon-button
-          aria-label="求人作成する"
           matTooltip="求人作成する"
-          (click)="createJob()"
+          (click)="navigateEditor()"
           *ngIf="companyLoginStatus"
         >
           <mat-icon>add</mat-icon>
         </button>
         <ng-container *ngIf="user$ | async as user">
           <div class="header__user-icon">
-            <button
-              mat-icon-button
-              aria-label="ユーザー画像"
-              [matMenuTriggerFor]="menu"
-            >
+            <button mat-icon-button [matMenuTriggerFor]="menu">
               <img [src]="user.photoURL" alt="" />
             </button>
           </div>
         </ng-container>
         <mat-menu #menu="matMenu">
-          <button
-            mat-menu-item
-            aria-label="ログアウト"
-            *ngIf="user$ | async"
-            (click)="logout()"
-          >
+          <button mat-menu-item *ngIf="user$ | async" (click)="logout()">
             <mat-icon>input</mat-icon>
             <span>ログアウト</span>
           </button>
-          <button
-            mat-menu-item
-            aria-label="お気に入り一覧"
-            routerLink="/user/keep"
-            *ngIf="userLoginStatus"
-          >
+          <button mat-menu-item routerLink="/user/keep" *ngIf="userLoginStatus">
             <mat-icon>star</mat-icon>
             <span>お気に入り一覧</span>
           </button>
           <ng-container *ngIf="userLoginStatus">
-            <button
-              mat-menu-item
-              aria-label="プロフィール"
-              routerLink="/user/mypage"
-            >
+            <button mat-menu-item routerLink="/user/mypage">
               <mat-icon>person</mat-icon>
               <span>プロフィール</span>
             </button>
           </ng-container>
           <ng-container *ngIf="companyLoginStatus">
-            <button
-              mat-menu-item
-              aria-label="プロフィール"
-              routerLink="/company/profile"
-            >
+            <button mat-menu-item routerLink="/company/profile">
               <mat-icon>person</mat-icon>
               <span>プロフィール</span>
             </button>
           </ng-container>
           <ng-container *ngIf="companyLoginStatus">
-            <button
-              mat-menu-item
-              aria-label="自社求人一覧"
-              routerLink="/company/job/list"
-            >
+            <button mat-menu-item routerLink="/company/job/list">
               <mat-icon>event_note</mat-icon>
               <span>自社求人一覧</span>
             </button>
           </ng-container>
-          <button mat-menu-item aria-label="プラン" routerLink="/plan">
+          <button mat-menu-item routerLink="/plan">
             <mat-icon>payment</mat-icon>
             <span>プラン</span>
           </button>
@@ -94,12 +66,7 @@
       </div>
       <ng-container *ngIf="!(user$ | async) && searchNone()">
         <div class="header-auth">
-          <button
-            (click)="authDialog()"
-            mat-raised-button
-            aria-label="ログイン"
-            color="accent"
-          >
+          <button (click)="authDialog()" mat-raised-button color="accent">
             <span>ログイン</span>
           </button>
         </div>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -17,9 +17,9 @@
           <mat-icon>search</mat-icon>
         </button>
         <button
-          routerLink="/company/recruitment"
           mat-icon-button
           matTooltip="求人作成する"
+          (click)="createJob()"
           *ngIf="companyLoginStatus"
         >
           <mat-icon>add</mat-icon>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -25,8 +25,6 @@ export class HeaderComponent implements OnInit, DoCheck {
   companyLoginStatus: boolean;
   user$ = this.authService.afUser$;
   display: boolean;
-  planCompany: string;
-  length: number;
 
   @Output() addOops: EventEmitter<string> = new EventEmitter();
 
@@ -69,16 +67,16 @@ export class HeaderComponent implements OnInit, DoCheck {
     this.loginToggle();
   }
 
-  createJob() {
+  navigateEditor() {
     this.jobPostService
       .getMyCompanyJobs(this.authService.uid)
       .pipe(take(1))
       .subscribe(jobs => {
-        this.length = jobs.length;
+        const jobLength = jobs.length;
         this.feeService.getCustomer().subscribe((customer: any) => {
-          this.planCompany = customer.subscriptionId;
+          const planCompany = customer.subscriptionId;
           if (
-            (this.length > 1 && customer === undefined) ||
+            (jobLength > 1 && customer === undefined) ||
             customer.subscriptionId === null
           ) {
             this.snackbar.open(
@@ -89,7 +87,7 @@ export class HeaderComponent implements OnInit, DoCheck {
                 verticalPosition: 'top'
               }
             );
-          } else if (this.length < 1 || this.planCompany) {
+          } else if (jobLength < 1 || planCompany) {
             this.router.navigateByUrl('/company/recruitment');
           }
         });


### PR DESCRIPTION
## 該当issue
- #310 課金したときの処理を考え・作成する
### 実装内容
- 投稿数が一件以上あるか、一件もない、プレミアムプランに登録していたら求人作成
- 投稿数が一件以上あって課金IDが存在しない場合はsnackbar表示

### 変更点の実際の挙動

<img width="1432" alt="スクリーンショット 2020-04-15 3 07 31" src="https://user-images.githubusercontent.com/49673112/79296883-9d677580-7f17-11ea-8ba7-aafadaccfa28.png">

ご確認よろしくお願い致します。
